### PR TITLE
:arrow_up: Bump uvicorn[standard] in /docker-images

### DIFF
--- a/docker-images/requirements.txt
+++ b/docker-images/requirements.txt
@@ -1,3 +1,3 @@
-uvicorn[standard]==0.15.0
+uvicorn[standard]==0.17.6
 gunicorn==20.1.0
 fastapi==0.68.1


### PR DESCRIPTION
Bumps [uvicorn[standard]](https://github.com/encode/uvicorn) from 0.15.0 to 0.17.6.
- [Release notes](https://github.com/encode/uvicorn/releases)
- [Changelog](https://github.com/encode/uvicorn/blob/master/CHANGELOG.md)
- [Commits](https://github.com/encode/uvicorn/compare/0.15.0...0.17.6)

---
updated-dependencies:
- dependency-name: uvicorn[standard]
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>